### PR TITLE
Added support for hyperlinks, superscripts, and subscripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ require 'docx'
 # Retrieve and display paragraphs as html
 doc = Docx::Document.open('example.docx')
 doc.paragraphs.each do |p|
-  puts p.to_html
+  puts p.to_html # preserves any bold, italic, underline, hyperlinks, superscript, and subscript character formatting from the original docx file.
 end
 ```
 

--- a/lib/docx/containers/hyperlink.rb
+++ b/lib/docx/containers/hyperlink.rb
@@ -1,0 +1,52 @@
+require 'docx/containers/container'
+
+module Docx
+  module Elements
+    module Containers
+      class Hyperlink
+        include Container
+        include Elements::Element
+        
+        def initialize(node, document_properties = {})
+          @node = node
+          @document_properties = document_properties
+          @hyperlinks = @document_properties[:hyperlinks]
+        end
+        
+        def to_html
+          "<a href='#{@hyperlinks[self.id]}'>#{inner_html}</a>"
+        end
+        
+        def to_s
+          inner_text
+        end
+        
+        # Array of text runs contained within paragraph
+        def text_runs
+          @node.xpath('w:r').map { |r_node| Containers::TextRun.new(r_node, @document_properties) }
+        end
+        
+        def id
+          @node.attributes['id'].value
+        end
+        
+        def inner_html
+          html = ""
+          text_runs.each do |run|
+            html << run.to_html
+          end
+          html
+        end
+        
+        def inner_text
+          text = ""
+          text_runs.each do |run|
+            text << run.to_s
+          end
+          text
+        end
+
+      end
+    end
+  end
+end

--- a/lib/docx/containers/paragraph.rb
+++ b/lib/docx/containers/paragraph.rb
@@ -80,6 +80,11 @@ module Docx
           size_tag ? size_tag.attributes['val'].value.to_i / 2 : @font_size
         end
         
+        def style
+          style_tag = @node.xpath('w:pPr//w:pStyle').first
+          style_tag ? style_tag.attributes['val'].value.to_s : 'Normal'
+        end
+        
         alias_method :text, :to_s
 
         private

--- a/lib/docx/containers/paragraph.rb
+++ b/lib/docx/containers/paragraph.rb
@@ -13,11 +13,6 @@ module Docx
           'p'
         end
         
-        def to_swear
-          "yo ho ho"
-        end
-
-
         # Child elements: pPr, r, fldSimple, hlink, subDoc
         # http://msdn.microsoft.com/en-us/library/office/ee364458(v=office.11).aspx
         def initialize(node, document_properties = {})

--- a/lib/docx/containers/paragraph.rb
+++ b/lib/docx/containers/paragraph.rb
@@ -1,4 +1,5 @@
 require 'docx/containers/text_run'
+require 'docx/containers/hyperlink'
 require 'docx/containers/container'
 
 module Docx
@@ -10,6 +11,10 @@ module Docx
 
         def self.tag
           'p'
+        end
+        
+        def to_swear
+          "yo ho ho"
         end
 
 
@@ -44,7 +49,7 @@ module Docx
         # Return paragraph as a <p></p> HTML fragment with formatting based on properties.
         def to_html
           html = ''
-          text_runs.each do |text_run|
+          text_runs_with_hyperlinks.each do |text_run|
             html << text_run.to_html
           end
           styles = { 'font-size' => "#{font_size}pt" }
@@ -52,10 +57,20 @@ module Docx
           html_tag(:p, content: html, styles: styles)
         end
 
-
         # Array of text runs contained within paragraph
         def text_runs
           @node.xpath('w:r|w:hyperlink/w:r').map { |r_node| Containers::TextRun.new(r_node, @document_properties) }
+        end
+
+        # Array of text runs or hyperlinks contained within paragraph
+        def text_runs_with_hyperlinks
+          @node.xpath('w:r|w:hyperlink').map do |r_node| 
+            if 'hyperlink' == r_node.name
+              Containers::Hyperlink.new(r_node,@document_properties)
+            else
+              Containers::TextRun.new(r_node, @document_properties)
+            end
+          end
         end
 
         # Iterate over each text run within a paragraph

--- a/lib/docx/containers/text_run.rb
+++ b/lib/docx/containers/text_run.rb
@@ -10,7 +10,9 @@ module Docx
         DEFAULT_FORMATTING = {
           italic:    false,
           bold:      false,
-          underline: false
+          underline: false,
+          superscript: false,
+          subscript: false
         }
         
         def self.tag
@@ -49,7 +51,9 @@ module Docx
           {
             italic:    !@node.xpath('.//w:i').empty?,
             bold:      !@node.xpath('.//w:b').empty?,
-            underline: !@node.xpath('.//w:u').empty?
+            underline: !@node.xpath('.//w:u').empty?,
+            superscript: (vert_align(@node) == 'superscript'),
+            subscript: (vert_align(@node) == 'subscript')
           }
         end
 
@@ -62,6 +66,8 @@ module Docx
           html = @text
           html = html_tag(:em, content: html) if italicized?
           html = html_tag(:strong, content: html) if bolded?
+          html = html_tag(:superscript, content: html) if superscript?
+          html = html_tag(:subscript, content: html) if subscript?
           styles = {}
           styles['text-decoration'] = 'underline' if underlined?
           # No need to be granular with font size down to the span level if it doesn't vary.
@@ -81,11 +87,26 @@ module Docx
         def underlined?
           @formatting[:underline]
         end
+        
+        def superscript?
+          @formatting[:superscript]
+        end
+
+        def subscript?
+          @formatting[:subscript]
+        end
 
         def font_size
           size_tag = @node.xpath('w:rPr//w:sz').first
           size_tag ? size_tag.attributes['val'].value.to_i / 2 : @font_size
         end
+        
+        private
+        def vert_align(node)
+          va = node.xpath('.//w:vertAlign').first
+          va ? va.attributes['val'].value : ''
+        end
+        
       end
     end
   end


### PR DESCRIPTION
For my purposes, I needed to preserve hyperlinks, superscripts, and subscripts in our word files, so I added support for this. I thought it would probably be useful for others. 

Please let me know if you have any questions.
